### PR TITLE
feat: Add and use vue-i18n for UI text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Do Five Things is a web application built with Ruby on Rails that helps users ma
 - [Usage](#usage)
 - [Contributing](#contributing)
 - [Docs](#docs)
+- [i18n](#i18n)
 
 ## Ruby and Rails Versions
 
@@ -84,3 +85,8 @@ Please ensure units are present and passing for any work involves logic or goes 
 - [Ruby On Rails guides](https://guides.rubyonrails.org/)
 - [vite-ruby](https://vite-ruby.netlify.app/)
 - [Vue.js](https://vuejs.org/)
+
+## i18n
+
+This app uses [vue-18n](https://vue-i18n.intlify.dev/) to provide translations for the app.
+The app isn't currently translated into languages other than English, but using i18n helps keep all of the UI text in one place. This makes it easier for non-coders to contribute strings, and will help us scale languages more gracefully in the future.

--- a/app/frontend/entrypoints/inertia.js
+++ b/app/frontend/entrypoints/inertia.js
@@ -1,7 +1,13 @@
 import { createInertiaApp } from '@inertiajs/vue3'
+
 import { createApp, h } from 'vue'
 
+import { setupI18n } from '../i18n'
+
 import BaseLayout from '../layouts/BaseLayout.vue'
+
+const i18n = setupI18n()
+
 
 createInertiaApp({
   // Set default page title
@@ -24,6 +30,7 @@ createInertiaApp({
   setup({ el, App, props, plugin }) {
     createApp({ render: () => h(App, props) })
       .use(plugin)
+      .use(i18n)
       .mount(el)
   },
 })

--- a/app/frontend/i18n.js
+++ b/app/frontend/i18n.js
@@ -1,0 +1,20 @@
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+
+/**
+ * @param {object} options - Options to be passed to [vue-i18n](https://vue-i18n.intlify.dev/api/general.html#i18nadditionaloptions)
+ */
+export const setupI18n = (options = {locale: 'en'}) => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: options.locale,
+    fallbackLocale: 'en',
+    messages: {
+      en
+    }
+  })
+
+  document.querySelector('html').setAttribute('lang', options.locale)
+
+  return i18n
+}

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "pageTitles": {
+    "settings": "Settings",
+    "today": "Today",
+    "progress": "Progress"
+  }
+}

--- a/app/frontend/pages/SettingsPage.vue
+++ b/app/frontend/pages/SettingsPage.vue
@@ -1,8 +1,18 @@
 <template>
   <div>
-   <h1>Settings page (TODO: Refactor into a reusable, styled component)</h1>
+    <h1>{{ $t('pageTitles.settings') }}</h1>
+    <p>Example computed string. It should say "today": {{ exampleComputedString }}</p>
+   <p>This is the settings page (TODO: Refactor into a reusable, styled component)</p>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { computed } from 'vue'
+
+const { t } = useI18n()
+
+const exampleComputedString = computed(() => {
+  if (true === true) return t('pageTitles.today')
+})
 </script>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postcss": "^8.4.38",
     "stimulus-vite-helpers": "^3.1.0",
     "tailwindcss": "^3.4.4",
-    "vue": "^3.4.31"
+    "vue": "^3.4.31",
+    "vue-i18n": "9"
   },
   "scripts": {},
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,27 @@
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
 
+"@intlify/core-base@9.13.1":
+  version "9.13.1"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.13.1.tgz#bd1f38e665095993ef9b67aeeb794f3cabcb515d"
+  integrity sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==
+  dependencies:
+    "@intlify/message-compiler" "9.13.1"
+    "@intlify/shared" "9.13.1"
+
+"@intlify/message-compiler@9.13.1":
+  version "9.13.1"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.13.1.tgz#ff8129badf77db3fb648b8d3cceee87c8033ed0a"
+  integrity sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==
+  dependencies:
+    "@intlify/shared" "9.13.1"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@9.13.1":
+  version "9.13.1"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.13.1.tgz#202741d11ece1a9c7480bfd3f27afcf9cb8f72e4"
+  integrity sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -458,6 +479,11 @@
   dependencies:
     "@vue/compiler-dom" "3.4.31"
     "@vue/shared" "3.4.31"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.3.tgz#b23a588154cba8986bba82b6e1d0248bde3fd1a0"
+  integrity sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==
 
 "@vue/reactivity@3.4.31":
   version "3.4.31"
@@ -1734,7 +1760,7 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-source-map-js@^1.2.0:
+source-map-js@^1.0.2, source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
@@ -1954,6 +1980,15 @@ vite@^5.0.0:
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vue-i18n@9:
+  version "9.13.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-9.13.1.tgz#a292c8021b7be604ebfca5609ae1f8fafe5c36d7"
+  integrity sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==
+  dependencies:
+    "@intlify/core-base" "9.13.1"
+    "@intlify/shared" "9.13.1"
+    "@vue/devtools-api" "^6.5.0"
 
 vue@^3.4.31:
   version "3.4.31"


### PR DESCRIPTION
## Context

Devs and non-devs managing UI strings

## Work done

Added `vue-i18n` ([docs](https://vue-i18n.intlify.dev/)) package to manage strings and make it easier for us to add additional languages later.

## Manual testing instructions

1. Run yarn to add the package
2. Serve the app (./bin/dev)
3. Navigate to the /settings page
- Expect that there are no console errors or warnings
- Expect the translated strings to show on the screen