### PR TITLE
fix: Add in active link styles

### DIFF
--- a/app/frontend/components/NavLink.vue
+++ b/app/frontend/components/NavLink.vue
@@ -1,5 +1,9 @@
 <template>
-  <Link :href="linkDest" class="flex flex-col items-center justify-end h-full rounded-t-xl text-dft-black hover:bg-dft-secondary-dimmed">
+  <Link 
+  :href="linkDest" 
+  :class="{ 'inertia-link-exact-active': $page.url === linkDest }"
+  class="flex flex-col items-center justify-end h-full rounded-t-xl text-dft-black hover:bg-dft-secondary-dimmed"
+  >
     <BaseIcon :icon="icon" />
     <slot />
   </Link>
@@ -22,3 +26,9 @@ defineProps({
   }
 })
 </script>
+
+<style scoped>
+.inertia-link-exact-active {
+  @apply bg-dft-secondary-dimmed;
+}
+</style>


### PR DESCRIPTION
## Context
A user navigating between pages.

## Work done
Added active link styling so that the user can know which page they're on (other than by the URL).

## Manual testing instructions
1. serve the app (yarn dev)
2. Go to /today
- Expect the "today" link in the bottom of the page to be styled as per the hifi v2 Figmas