### PR TITLE
feat: Add the today page with clickable example tasks

### DIFF
--- a/app/frontend/components/NavLink.vue
+++ b/app/frontend/components/NavLink.vue
@@ -1,5 +1,9 @@
 <template>
-  <Link :href="linkDest" class="flex flex-col items-center justify-end h-full rounded-t-xl text-dft-black hover:bg-dft-secondary-dimmed">
+  <Link 
+  :href="linkDest" 
+  :class="{ 'inertia-link-exact-active': $page.url === linkDest }"
+  class="flex flex-col items-center justify-end h-full rounded-t-xl text-dft-black hover:bg-dft-secondary-dimmed"
+  >
     <BaseIcon :icon="icon" />
     <slot />
   </Link>
@@ -22,3 +26,9 @@ defineProps({
   }
 })
 </script>
+
+<style scoped>
+.inertia-link-exact-active {
+  @apply bg-dft-secondary-dimmed;
+}
+</style>

--- a/app/frontend/components/TaskCheck.stories.js
+++ b/app/frontend/components/TaskCheck.stories.js
@@ -1,0 +1,16 @@
+import TaskCheck from './TaskCheck.vue';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+export default {
+  title: 'Buttons/TaskCheck',
+  component: TaskCheck,
+  tags: ['autodocs'],
+};
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Base = {
+  args: {
+    isChecked: false,
+    task: { text: 'Wash face', id: 99},
+  },
+};

--- a/app/frontend/components/TaskCheck.vue
+++ b/app/frontend/components/TaskCheck.vue
@@ -1,0 +1,25 @@
+<template>
+  <button :aria-pressed="isChecked"
+    class="flex items-center w-full gap-4 p-5 border text-start border-dft-primary rounded-dft-input">
+    <span class="w-6 h-6 border-2 rounded shrink-0 border-dft-primary" :class="{ 'bg-dft-primary': isChecked }"></span>
+
+    <span class="px-2" :class="{ 'line-through': isChecked }">{{ task.text }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import { Task } from '../types'
+
+defineProps({
+  isChecked: {
+    type: Boolean,
+    default: false
+  },
+  task: {
+    type: Object as PropType<Task>,
+    required: true
+  }
+})
+
+</script>

--- a/app/frontend/components/TaskInput.vue
+++ b/app/frontend/components/TaskInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-baseline gap-4 py-5 dft-border">
+  <div class="flex items-baseline gap-4 py-5 border-2 border-dft-primary rounded-dft-input">
     <label :for="taskId" class="flex items-center text-xl ml-9">
       <span class="sr-only">{{ $t('labels.task') }}</span>
       <span>{{ taskNumber }}.</span>

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -22,9 +22,13 @@
   }
 }
 
+@layer components {
+  .dft-list-layout {
+  @apply flex flex-col max-w-sm gap-6 mx-auto;
+  }
+}
 @layer utilities {
-  .dft-border {
-    @apply rounded-[20px] border-4;
-    @apply border-dft-primary;
+  .dft-prose-link {
+    @apply border-b border-dft-primary;
   }
 }

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -14,5 +14,12 @@
     "settings": "Settings",
     "today": "Today",
     "progress": "Progress"
+  },
+  "emptyStates": {
+    "todayPage": {
+      "text1": "No tasks yet! Go to",
+      "link1": "settings",
+      "text2": "to add."
+    }
   }
 }

--- a/app/frontend/pages/SettingsPage.vue
+++ b/app/frontend/pages/SettingsPage.vue
@@ -4,7 +4,7 @@
 
     <h2 class="mb-16 text-2xl text-center">{{ $t('flavorText.whatFiveThings') }}</h2>
 
-    <ol class="flex flex-col max-w-sm gap-6 mx-auto">
+    <ol class="dft-list-layout">
       <li v-for="(num, index) in 5" :key="index">
         <TaskInput :taskNumber="num" v-model="taskInputs[index]" />
       </li>

--- a/app/frontend/pages/TodayPage.vue
+++ b/app/frontend/pages/TodayPage.vue
@@ -1,9 +1,46 @@
 <template>
   <div>
     <h1>{{ $t('pageTitles.today') }}</h1>
-   <p>This is the today page</p>
+    <h2 class="mb-16 text-2xl text-center">
+      {{ $t('emptyStates.todayPage.text1') }}
+      <Link class="dft-prose-link" href="/settings">{{ $t('emptyStates.todayPage.link1') }}</Link>
+      {{ $t('emptyStates.todayPage.text2') }}
+    </h2>
+
+    <ol class="dft-list-layout">
+      <li v-for="task in sortedTasks" :key="task.id">
+        <TaskCheck :task="task" :isChecked="task.completed" @click="updateIsChecked(task.id)" />
+      </li>
+    </ol>
   </div>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+
+import TaskCheck from '../components/TaskCheck.vue';
+
+import { computed, reactive } from 'vue'
+import { Task } from '../types'
+
+const tasks: Task[] = reactive([
+  { id: 939, order: 3, completed: true, text: "Wash my face" },
+  { id: 297, order: 4, completed: false, text: "Make my bed and do another thing but this other thing might grab my attention so I will try to do it too" },
+  { id: 584, order: 2, completed: false, text: "Shower!" },
+  { id: 837, order: 5, completed: true, text: "Empty litter" },
+  { id: 102, order: 1, completed: false, text: "Brush teeth" }
+])
+
+const sortedTasks = computed(() => {
+  return tasks.sort((a,b) => { return a.order - b.order })
+})
+
+
+const updateIsChecked = (taskId: Task['id']) => {
+  const currentTask = tasks.find(el => el.id === taskId)
+
+  if(currentTask) {
+    currentTask.completed = !currentTask.completed
+  }
+}
 </script>

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -1,0 +1,6 @@
+export type Task = {
+  id: number
+  text: string,
+  order: number,
+  completed: boolean
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,9 @@ module.exports = {
       fontFamily: {
         sans: ['Righteous', ...defaultTheme.fontFamily.sans],
       },
+      borderRadius: {
+        'dft-input': '20px'
+      },
       colors: {
         'dft-white': '#FFFFFF',
         'dft-black': '#000000',


### PR DESCRIPTION
## Context
A user ticking off tasks each day

## Work done
- Added a `TaskCheck` component and it's Storybook (no tests necessary)
- Updated some styling for DRYness and clarity
- Used the `TaskCheck` in the today page to demo a list of tasks

## Manual testing instructions
1. serve the app (yarn dev)
2. navigate to /today
- Expect to see five tasks styled as per Figma
3. navigate to each of the tasks
- Expect the screen reader to read out the name and pressed value
4. Toggle each of the tasks with keyboard and/or mouse (try each, please)
- Expect the styling to change as per Figma

## Gotchas
The tasks do not rearrange themselves, but I'll do this in a future PR.