### PR TITLE
feat: Add validaton and localStorage saving

### DIFF
--- a/app/frontend/components/BaseButton.stories.js
+++ b/app/frontend/components/BaseButton.stories.js
@@ -1,0 +1,28 @@
+import BaseButton from './BaseButton.vue';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+export default {
+  title: 'Controls/BaseButton',
+  component: BaseButton,
+  tags: ['autodocs'],
+  render: (args) => ({
+    components: { BaseButton },
+    setup() {
+      return { args };
+    },
+    template: `
+      <BaseButton v-bind="args">
+        <template v-slot:default>
+          {{ args.slotText }}
+        </template>
+      </BaseButton>
+    `,
+  }),
+};
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Base = {
+  args: {
+    slotText: 'Click me for the answer',
+  }
+};

--- a/app/frontend/components/BaseButton.vue
+++ b/app/frontend/components/BaseButton.vue
@@ -1,0 +1,16 @@
+<template>
+  <button class="py-3 px-12 text-2xl border-2 rounded-full transition ease-in-out focus:text-dft-black active:text-dft-black active:bg-dft-primary hover:text-dft-black hover:bg-dft-primary"
+  :class="hasError ? 'text-dft-error border-dft-error' : 'text-dft-primary border-dft-primary'"
+  >
+    <slot/>
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps({
+  hasError: {
+    type: Boolean,
+    default: false
+  }
+})
+</script>

--- a/app/frontend/components/TaskInput.vue
+++ b/app/frontend/components/TaskInput.vue
@@ -1,18 +1,22 @@
 <template>
-  <div class="flex items-baseline gap-4 py-5 border-2 border-dft-primary rounded-dft-input">
-    <label :for="taskId" class="flex items-center text-xl ml-9">
+  <div :class="hasError ? 'border-dft-error ring-dft-error' : 'border-dft-primary ring-dft-primary'"
+    class="transition ease-in-out focus-within:ring-4 ring-inset flex items-baseline gap-4 py-5 px-9 border-2 rounded-dft-input">
+
+    <label :for="taskId" class="flex items-center text-xl" :class="{ 'text-dft-error': hasError }">
       <span class="sr-only">{{ $t('labels.task') }}</span>
       <span>{{ taskNumber }}.</span>
+      <span v-if="hasError">*</span>
     </label>
-    <input class="p-0 leading-none bg-transparent border-0 border-b border-dft-white" :id="taskId" type="text"
-      :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />
+
+    <input :aria-describedby="$attrs['aria-describedby'] as string || undefined" :aria-invalid="hasError || undefined"
+      class="w-full p-0 leading-none bg-transparent border-0 border-b" :id="taskId" type="text"
+      :class="hasError ? 'border-dft-error' : 'border-dft-white'"
+      :value="modelValue" @change="$emit('update:modelValue', ($event.target as HTMLInputElement).value)" />
   </div>
 </template>
 
 <script setup lang="ts">
 import SetupUid from '../composables/SetupUid'
-
-import { ref } from 'vue'
 
 defineProps({
   modelValue: {
@@ -22,6 +26,10 @@ defineProps({
   taskNumber: {
     type: Number,
     default: 1
+  },
+  hasError: {
+    type: Boolean,
+    default: false
   }
 })
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -24,7 +24,7 @@
 
 @layer components {
   .dft-list-layout {
-  @apply flex flex-col max-w-sm gap-6 mx-auto;
+  @apply flex flex-col gap-6 mx-auto;
   }
 }
 @layer utilities {

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -3,6 +3,7 @@
     "whatFiveThings": "What 5 things do you want to get done?"
   },
   "labels": {
+    "save": "Save",
     "task": "Task"
   },
   "pageTitles": {
@@ -21,5 +22,9 @@
       "link1": "settings",
       "text2": "to add."
     }
+  },
+  "settingsPage": {
+    "legend": "*All fields required. When you’re done editing your tasks, click save and view your tasks in the Today page!",
+    "errorText": "*Not done just yet, fill out all tasks before saving!"
   }
 }

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -1,10 +1,13 @@
 {
   "flavorText": {
-    "whatFiveThings": "What 5 things do you want to get done?"
+    "whatFiveThings": "What 5 things do you want to get done?",
+    "youGotThis": "You got this!"
   },
   "labels": {
+    "completed": "Completed",
     "save": "Save",
-    "task": "Task"
+    "task": "Task",
+    "toDo": "To do"
   },
   "pageTitles": {
     "settings": "Settings",
@@ -17,6 +20,7 @@
     "progress": "Progress"
   },
   "emptyStates": {
+    "nothingToSee": "Nothing to see here ....",
     "todayPage": {
       "text1": "No tasks yet! Go to",
       "link1": "settings",

--- a/app/frontend/pages/SettingsPage.vue
+++ b/app/frontend/pages/SettingsPage.vue
@@ -1,30 +1,68 @@
 <template>
-  <div>
+  <form @submit.prevent="validateAndSave" class="flex flex-col">
     <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.settings') }}</h1>
 
     <h2 class="mb-16 text-2xl text-center">{{ $t('flavorText.whatFiveThings') }}</h2>
 
+    <p class="mt-5 order-last text-dft-error" id="legend">{{ $t('settingsPage.legend') }}</p>
+
     <ol class="dft-list-layout">
-      <li v-for="(num, index) in 5" :key="index">
-        <TaskInput :taskNumber="num" v-model="taskInputs[index]" />
+      <li v-for="(task, index) in tasks" :key="task.id">
+        <TaskInput :aria-describedby="`${anyError && !task.name ? 'errorText' : ''} legend`" :taskNumber="index + 1"
+          v-model="tasks[index].name" :hasError="anyError && !task.name" />
       </li>
     </ol>
 
-    <code>
-    Inputs: 
-    <ol>
-      <li v-for="(input, index) in taskInputs" :key="index">
-        {{ input }}
-      </li>
-    </ol>
-    </code>
-  </div>
+    <div aria-live="assertive" class="order-last mb-7 text-dft-error">
+      <p tabindex="-1" v-if="anyError" id="errorText" ref="errorTextRef">{{ $t('settingsPage.errorText') }}</p>
+    </div>
+
+    <BaseButton class="order-last my-5 mx-auto block" :hasError="anyError">
+      {{ $t('labels.save') }}
+    </BaseButton>
+  </form>
 </template>
 
 <script setup lang="ts">
+import BaseButton from '../components/BaseButton.vue'
 import TaskInput from '../components/TaskInput.vue';
 
-import { reactive } from 'vue'
+import { Ref, computed, nextTick, ref } from 'vue'
 
-const taskInputs = reactive([])
+interface Task {
+  id: number,
+  name: string
+}
+
+const tasks: Ref<Task[]> = ref(
+  localStorage.getItem('dftTasks') ?
+    JSON.parse(localStorage.getItem('dftTasks')!) :
+    [
+      { id: 1, name: '' },
+      { id: 2, name: '' },
+      { id: 3, name: '' },
+      { id: 4, name: '' },
+      { id: 5, name: '' },
+    ]
+)
+
+const anyEmpty = computed(() => {
+  if (!tasks.value || tasks.value.length === 0) return true
+
+  return tasks.value.some(task => {
+    return !Boolean(task.name)
+  })
+})
+
+const anyError = ref(false)
+const errorTextRef: Ref<HTMLElement | null> = ref(null)
+
+const validateAndSave = async () => {
+  anyEmpty.value ? anyError.value = true : anyError.value = false
+
+  await nextTick()
+  if (anyError.value && errorTextRef.value) errorTextRef.value?.focus()
+
+  localStorage.setItem('dftTasks', JSON.stringify(tasks.value))
+}
 </script>

--- a/app/frontend/pages/SettingsPage.vue
+++ b/app/frontend/pages/SettingsPage.vue
@@ -1,15 +1,15 @@
 <template>
-  <form @submit.prevent="validateAndSave" class="flex flex-col">
+  <form @submit.prevent="validateAndSave" class="mx-auto max-w-sm flex flex-col">
     <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.settings') }}</h1>
 
     <h2 class="mb-16 text-2xl text-center">{{ $t('flavorText.whatFiveThings') }}</h2>
 
-    <p class="mt-5 order-last text-dft-error" id="legend">{{ $t('settingsPage.legend') }}</p>
+    <p class="max-w-xs mx-auto p-6 pt-0 mt-5 order-last text-dft-error" id="legend">{{ $t('settingsPage.legend') }}</p>
 
     <ol class="dft-list-layout">
       <li v-for="(task, index) in tasks" :key="task.id">
-        <TaskInput :aria-describedby="`${anyError && !task.name ? 'errorText' : ''} legend`" :taskNumber="index + 1"
-          v-model="tasks[index].name" :hasError="anyError && !task.name" />
+        <TaskInput :aria-describedby="`${anyError && !task.text ? 'errorText' : ''} legend`" :taskNumber="index + 1"
+          v-model="tasks[index].text" :hasError="anyError && !task.text" />
       </li>
     </ol>
 
@@ -31,18 +31,18 @@ import { Ref, computed, nextTick, ref } from 'vue'
 
 interface Task {
   id: number,
-  name: string
+  text: string
 }
 
 const tasks: Ref<Task[]> = ref(
   localStorage.getItem('dftTasks') ?
     JSON.parse(localStorage.getItem('dftTasks')!) :
     [
-      { id: 1, name: '' },
-      { id: 2, name: '' },
-      { id: 3, name: '' },
-      { id: 4, name: '' },
-      { id: 5, name: '' },
+      { id: 1, order: 1, text: '', completed: false },
+      { id: 2, order: 2, text: '', completed: true },
+      { id: 3, order: 3, text: '', completed: false },
+      { id: 4, order: 4, text: '', completed: false },
+      { id: 5, order: 5, text: '', completed: false },
     ]
 )
 
@@ -50,7 +50,7 @@ const anyEmpty = computed(() => {
   if (!tasks.value || tasks.value.length === 0) return true
 
   return tasks.value.some(task => {
-    return !Boolean(task.name)
+    return !Boolean(task.text)
   })
 })
 

--- a/app/frontend/pages/TodayPage.vue
+++ b/app/frontend/pages/TodayPage.vue
@@ -1,14 +1,30 @@
 <template>
-  <div>
-    <h1>{{ $t('pageTitles.today') }}</h1>
+  <div class="mx-auto max-w-sm">
+    <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.today') }}</h1>
+
     <h2 class="mb-16 text-2xl text-center">
+      <template v-if="!tasks">
       {{ $t('emptyStates.todayPage.text1') }}
       <Link class="dft-prose-link" href="/settings">{{ $t('emptyStates.todayPage.link1') }}</Link>
       {{ $t('emptyStates.todayPage.text2') }}
+      </template>
+
+      <template v-else>
+        {{ $t('flavorText.youGotThis') }}
+      </template>
     </h2>
 
-    <ol class="dft-list-layout">
-      <li v-for="task in sortedTasks" :key="task.id">
+    <h3><span class="text-2xl">{{ $t('labels.toDo') }}</span> {{ incompleteTasks.length }}/{{ sortedTasks.length }}</h3>
+    <ol v-if="incompleteTasks.length" class="my-6 dft-list-layout">
+      <li v-for="task in incompleteTasks" :key="task.id">
+        <TaskCheck :task="task" :isChecked="task.completed" @click="updateIsChecked(task.id)" />
+      </li>
+    </ol>
+    <p class="ml-4 my-6" v-else>{{ $t('emptyStates.nothingToSee') }}</p>
+
+    <h3><span class="text-2xl">{{ $t('labels.completed') }}</span> {{ completeTasks.length }}/{{ sortedTasks.length }}</h3>
+    <ol class="my-6 dft-list-layout">
+      <li v-for="task in completeTasks" :key="task.id">
         <TaskCheck :task="task" :isChecked="task.completed" @click="updateIsChecked(task.id)" />
       </li>
     </ol>
@@ -23,18 +39,19 @@ import TaskCheck from '../components/TaskCheck.vue';
 import { computed, reactive } from 'vue'
 import { Task } from '../types'
 
-const tasks: Task[] = reactive([
-  { id: 939, order: 3, completed: true, text: "Wash my face" },
-  { id: 297, order: 4, completed: false, text: "Make my bed and do another thing but this other thing might grab my attention so I will try to do it too" },
-  { id: 584, order: 2, completed: false, text: "Shower!" },
-  { id: 837, order: 5, completed: true, text: "Empty litter" },
-  { id: 102, order: 1, completed: false, text: "Brush teeth" }
-])
+const tasks: Task[] = reactive(localStorage.getItem('dftTasks') ? JSON.parse(localStorage.getItem('dftTasks')!) : [])
 
 const sortedTasks = computed(() => {
   return tasks.sort((a,b) => { return a.order - b.order })
 })
 
+const incompleteTasks = computed(() => {
+  return sortedTasks.value.filter(task => !task.completed)
+})
+
+const completeTasks = computed(() => {
+  return sortedTasks.value.filter(task => task.completed)
+})
 
 const updateIsChecked = (taskId: Task['id']) => {
   const currentTask = tasks.find(el => el.id === taskId)
@@ -42,5 +59,7 @@ const updateIsChecked = (taskId: Task['id']) => {
   if(currentTask) {
     currentTask.completed = !currentTask.completed
   }
+
+  localStorage.setItem('dftTasks', JSON.stringify(sortedTasks.value))
 }
 </script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ module.exports = {
         'dft-secondary': '#90F8FF', // Light blue
         'dft-secondary-dimmed': '#68D5DC',
         'dft-accent': '#FF6584', // Coral
+        'dft-error': '#FF6584', // Error (Coral)
       }
     },
   },


### PR DESCRIPTION
## Context

A user who wants to ensure they're saving the form correctly.

## Work done
- Added validation for the inputs and the form
- Styled the inputs, button, and form when the form has any errors
- Announce to the user when the form is not valid on saving
- Saved the inputs to localStorage (helpful during development)

## Manual testing instructions
1. yarn run dev.
2. Navigate to /settings.
3. Without filling in all the inputs (you may fill out none, or some number less than the total), submit the form.
- Expect to see error states for all inputs
- Expect to hear the error state on SR
- Expect to see error text near the save button
- Expect focus to land on the error text
4. Begin filling in one of the previously empty inputs
- Expect the error styling and error describedby to go away
5. Fill in all the inputs
6. Submit the form
7. Refresh the page
- Expect each of the inputs to contain the updated data