### PR TITLE
feat: Add logic and styling for both lists on the today page

### DIFF
--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -24,7 +24,7 @@
 
 @layer components {
   .dft-list-layout {
-  @apply flex flex-col max-w-sm gap-6 mx-auto;
+  @apply flex flex-col gap-6 mx-auto;
   }
 }
 @layer utilities {

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -1,10 +1,13 @@
 {
   "flavorText": {
-    "whatFiveThings": "What 5 things do you want to get done?"
+    "whatFiveThings": "What 5 things do you want to get done?",
+    "youGotThis": "You got this!"
   },
   "labels": {
+    "completed": "Completed",
     "save": "Save",
-    "task": "Task"
+    "task": "Task",
+    "toDo": "To do"
   },
   "pageTitles": {
     "settings": "Settings",
@@ -17,6 +20,7 @@
     "progress": "Progress"
   },
   "emptyStates": {
+    "nothingToSee": "Nothing to see here ....",
     "todayPage": {
       "text1": "No tasks yet! Go to",
       "link1": "settings",

--- a/app/frontend/pages/SettingsPage.vue
+++ b/app/frontend/pages/SettingsPage.vue
@@ -1,15 +1,15 @@
 <template>
-  <form @submit.prevent="validateAndSave" class="flex flex-col">
+  <form @submit.prevent="validateAndSave" class="mx-auto max-w-sm flex flex-col">
     <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.settings') }}</h1>
 
     <h2 class="mb-16 text-2xl text-center">{{ $t('flavorText.whatFiveThings') }}</h2>
 
-    <p class="mt-5 order-last text-dft-error" id="legend">{{ $t('settingsPage.legend') }}</p>
+    <p class="max-w-xs mx-auto p-6 pt-0 mt-5 order-last text-dft-error" id="legend">{{ $t('settingsPage.legend') }}</p>
 
     <ol class="dft-list-layout">
       <li v-for="(task, index) in tasks" :key="task.id">
-        <TaskInput :aria-describedby="`${anyError && !task.name ? 'errorText' : ''} legend`" :taskNumber="index + 1"
-          v-model="tasks[index].name" :hasError="anyError && !task.name" />
+        <TaskInput :aria-describedby="`${anyError && !task.text ? 'errorText' : ''} legend`" :taskNumber="index + 1"
+          v-model="tasks[index].text" :hasError="anyError && !task.text" />
       </li>
     </ol>
 
@@ -31,18 +31,18 @@ import { Ref, computed, nextTick, ref } from 'vue'
 
 interface Task {
   id: number,
-  name: string
+  text: string
 }
 
 const tasks: Ref<Task[]> = ref(
   localStorage.getItem('dftTasks') ?
     JSON.parse(localStorage.getItem('dftTasks')!) :
     [
-      { id: 1, name: '' },
-      { id: 2, name: '' },
-      { id: 3, name: '' },
-      { id: 4, name: '' },
-      { id: 5, name: '' },
+      { id: 1, order: 1, text: '', completed: false },
+      { id: 2, order: 2, text: '', completed: true },
+      { id: 3, order: 3, text: '', completed: false },
+      { id: 4, order: 4, text: '', completed: false },
+      { id: 5, order: 5, text: '', completed: false },
     ]
 )
 
@@ -50,7 +50,7 @@ const anyEmpty = computed(() => {
   if (!tasks.value || tasks.value.length === 0) return true
 
   return tasks.value.some(task => {
-    return !Boolean(task.name)
+    return !Boolean(task.text)
   })
 })
 

--- a/app/frontend/pages/TodayPage.vue
+++ b/app/frontend/pages/TodayPage.vue
@@ -1,14 +1,30 @@
 <template>
-  <div>
-    <h1>{{ $t('pageTitles.today') }}</h1>
+  <div class="mx-auto max-w-sm">
+    <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.today') }}</h1>
+
     <h2 class="mb-16 text-2xl text-center">
+      <template v-if="!tasks">
       {{ $t('emptyStates.todayPage.text1') }}
       <Link class="dft-prose-link" href="/settings">{{ $t('emptyStates.todayPage.link1') }}</Link>
       {{ $t('emptyStates.todayPage.text2') }}
+      </template>
+
+      <template v-else>
+        {{ $t('flavorText.youGotThis') }}
+      </template>
     </h2>
 
-    <ol class="dft-list-layout">
-      <li v-for="task in sortedTasks" :key="task.id">
+    <h3><span class="text-2xl">{{ $t('labels.toDo') }}</span> {{ incompleteTasks.length }}/{{ sortedTasks.length }}</h3>
+    <ol v-if="incompleteTasks.length" class="my-6 dft-list-layout">
+      <li v-for="task in incompleteTasks" :key="task.id">
+        <TaskCheck :task="task" :isChecked="task.completed" @click="updateIsChecked(task.id)" />
+      </li>
+    </ol>
+    <p class="ml-4 my-6" v-else>{{ $t('emptyStates.nothingToSee') }}</p>
+
+    <h3><span class="text-2xl">{{ $t('labels.completed') }}</span> {{ completeTasks.length }}/{{ sortedTasks.length }}</h3>
+    <ol class="my-6 dft-list-layout">
+      <li v-for="task in completeTasks" :key="task.id">
         <TaskCheck :task="task" :isChecked="task.completed" @click="updateIsChecked(task.id)" />
       </li>
     </ol>
@@ -23,18 +39,19 @@ import TaskCheck from '../components/TaskCheck.vue';
 import { computed, reactive } from 'vue'
 import { Task } from '../types'
 
-const tasks: Task[] = reactive([
-  { id: 939, order: 3, completed: true, text: "Wash my face" },
-  { id: 297, order: 4, completed: false, text: "Make my bed and do another thing but this other thing might grab my attention so I will try to do it too" },
-  { id: 584, order: 2, completed: false, text: "Shower!" },
-  { id: 837, order: 5, completed: true, text: "Empty litter" },
-  { id: 102, order: 1, completed: false, text: "Brush teeth" }
-])
+const tasks: Task[] = reactive(localStorage.getItem('dftTasks') ? JSON.parse(localStorage.getItem('dftTasks')!) : [])
 
 const sortedTasks = computed(() => {
   return tasks.sort((a,b) => { return a.order - b.order })
 })
 
+const incompleteTasks = computed(() => {
+  return sortedTasks.value.filter(task => !task.completed)
+})
+
+const completeTasks = computed(() => {
+  return sortedTasks.value.filter(task => task.completed)
+})
 
 const updateIsChecked = (taskId: Task['id']) => {
   const currentTask = tasks.find(el => el.id === taskId)
@@ -42,5 +59,7 @@ const updateIsChecked = (taskId: Task['id']) => {
   if(currentTask) {
     currentTask.completed = !currentTask.completed
   }
+
+  localStorage.setItem('dftTasks', JSON.stringify(sortedTasks.value))
 }
 </script>


### PR DESCRIPTION
## Context

Users who are visiting the "Today" page of the app to track their checks.

## Work done

This PR makes it so that the Today page displays and updates two lists - todo and complete. When a task is checked as completed, the localStorage updates with the data so that you can refresh and still see your info.

## Testing instructions

1. yarn run dev
2. Navigate to /settings
3. Add your 5 tasks and save the form
4. Navigate to /today
- Expect to see that none of the items have been completed
5. Complete some of the items by clicking on them
- Expect to see that the item is added to the "Complete list"
- Expect to see the styling and placement of the item change
6. Refresh the page (soft)
- Expect the items and their todo/complete status to remain