### PR TITLE
feat: Add empty message for progress page

### DIFF
--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -25,6 +25,11 @@
       "text1": "No tasks yet! Go to",
       "link1": "settings",
       "text2": "to add."
+    },
+    "progressPage": {
+      "text1": "No progress yet...complete all 5 tasks in the",
+      "link1": "Today",
+      "text2": "page first!"
     }
   },
   "settingsPage": {

--- a/app/frontend/pages/ProgressPage.vue
+++ b/app/frontend/pages/ProgressPage.vue
@@ -1,9 +1,17 @@
 <template>
-  <div>
-    <h1>{{ $t('pageTitles.progress') }}</h1>
-   <p>This is the progress page</p>
+  <div class="mx-auto max-w-sm">
+    <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.progress') }}</h1>
+    <p class="mb-16 text-xl text-center">
+      {{ $t('emptyStates.progressPage.text1') }}
+      <Link class="dft-prose-link" href="/today">
+        {{ $t('emptyStates.progressPage.link1') }}
+      </Link>
+      {{ $t('emptyStates.progressPage.text2') }}
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
+import { Link, router } from '@inertiajs/vue3'
+
 </script>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_23_170320) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_17_213351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "counters", force: :cascade do |t|
+    t.integer "click"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "goals", force: :cascade do |t|
     t.date "start_date"
@@ -30,9 +36,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_23_170320) do
     t.integer "order"
     t.text "text"
     t.boolean "completed"
-    t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "completed_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## Context

Users who are visiting the "Progress" page of the app to check their progress on doing checks for the year.

## Work done

This PR shows the empty state for the Progress page. At this point a user has not completed any days of checks.

## Testing instructions

1. yarn run dev
2. Navigate to /progress
- Expect to see the empty message of the progress page.
3. Click on the "Today" inline link in the text.
- Expect to be led back to the Today page.