### PR TITLE
feat: Display progress on progress page

### DIFF
--- a/app/controllers/progress_page_controller.rb
+++ b/app/controllers/progress_page_controller.rb
@@ -1,5 +1,5 @@
 class ProgressPageController < ApplicationController
   def index
-    render inertia: 'ProgressPage', props: { progs: Goal.last.daily_progs }
+    render inertia: 'ProgressPage', props: { progs: Goal.last.daily_progs, startdate: Goal.last.start_date }
   end
 end

--- a/app/frontend/components/BaseIcon.vue
+++ b/app/frontend/components/BaseIcon.vue
@@ -105,6 +105,12 @@
     <rect width="74" height="11" rx="5.5" fill="#FAFAFA" />
     <path d="M0 5.5C0 2.46243 2.46243 0 5.5 0H51V11H5.5C2.46244 11 0 8.53757 0 5.5Z" fill="black" />
   </svg>
+  <svg v-if="icon === 'arrowRight'" xmlns="http://www.w3.org/2000/svg" width="8" height="17" viewBox="0 0 8 17" fill="none">
+    <path d="M1.00004 1L7.0813 8.86987L1.00004 16.0243" stroke="#FAFAFA" />
+  </svg>
+  <svg v-if="icon === 'arrowLeft'" xmlns="http://www.w3.org/2000/svg" width="8" height="17" viewBox="0 0 8 17" fill="none">
+    <path d="M7.08126 1.0199L0.999999 8.88976L7.08126 16.0442" stroke="#FAFAFA" />
+  </svg>
 </template>
 
 <script setup lang="ts">
@@ -113,7 +119,7 @@ defineProps({
     type: String,
     default: '',
     validator(iconName: string) {
-      return ['cog', 'sun', 'thermometer'].includes(iconName)
+      return ['arrowLeft', 'arrowRight', 'cog', 'sun', 'thermometer'].includes(iconName)
     }
   },
   iconAlt: {

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -30,5 +30,55 @@
   "settingsPage": {
     "legend": "*All fields required. When you’re done editing your tasks, click save and view your tasks in the Today page!",
     "errorText": "*Not done just yet, fill out all tasks before saving!"
+  },
+  "progressPage": {
+    "completedText": "{count}/ 182 Days",
+    "tableCaptionMonth": "Progress for the month of {month}, with {count} days completed.",
+    "statusComplete": "Complete",
+    "statusIncomplete": "Incomplete"
+  },
+  "months": {
+    "0": "January",
+    "1": "February",
+    "2": "March",
+    "3": "April",
+    "4": "May",
+    "5": "June",
+    "6": "July",
+    "7": "August",
+    "8": "September",
+    "9": "October",
+    "10": "November",
+    "11": "December"
+  },
+  "daysOfTheWeek": {
+    "0": {
+      "abbreviation": "S",
+      "name": "Sunday"
+    },
+    "1": {
+      "abbreviation": "M",
+      "name": "Monday"
+    },
+    "2": {
+      "abbreviation": "T",
+      "name": "Tuesday"
+    },
+    "3": {
+      "abbreviation": "W",
+      "name": "Wednesday"
+    },
+    "4": {
+      "abbreviation": "T",
+      "name": "Thursday"
+    },
+    "5": {
+      "abbreviation": "F",
+      "name": "Friday"
+    },
+    "6": {
+      "abbreviation": "S",
+      "name": "Saturday"
+    }
   }
 }

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -6,10 +6,10 @@
   "labels": {
     "completed": "Completed",
     "calendar": {
-      "backMonth": "Previous month",
-      "forwardMonth": "Next month",
-      "noFutureDates": "No future dates",
-      "noPreviousDates": "No previous dates"
+      "backMonth": "Go to previous month",
+      "forwardMonth": "Go to next month",
+      "noFutureDates": "No future dates available.",
+      "noPreviousDates": "No previous dates available."
     },
     "save": "Save",
     "task": "Task",
@@ -38,8 +38,11 @@
     "errorText": "*Not done just yet, fill out all tasks before saving!"
   },
   "progressPage": {
+    "calendar": "Calendar",
+    "completedPercent": "{percent}% complete",
     "completedText": "{count}/ 182 Days",
     "tableCaptionMonth": "Progress for the month of {month}, with {completecount} days completed and {partiallycompletecount} days partially completed.",
+    "stats": "Statistics",
     "statusComplete": "Complete",
     "statusIncomplete": "Incomplete",
     "statusPartiallyComplete": "Partially complete"

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -5,6 +5,12 @@
   },
   "labels": {
     "completed": "Completed",
+    "calendar": {
+      "backMonth": "Previous month",
+      "forwardMonth": "Next month",
+      "noFutureDates": "No future dates",
+      "noPreviousDates": "No previous dates"
+    },
     "save": "Save",
     "task": "Task",
     "toDo": "To do"
@@ -33,9 +39,10 @@
   },
   "progressPage": {
     "completedText": "{count}/ 182 Days",
-    "tableCaptionMonth": "Progress for the month of {month}, with {count} days completed.",
+    "tableCaptionMonth": "Progress for the month of {month}, with {completecount} days completed and {partiallycompletecount} days partially completed.",
     "statusComplete": "Complete",
-    "statusIncomplete": "Incomplete"
+    "statusIncomplete": "Incomplete",
+    "statusPartiallyComplete": "Partially complete"
   },
   "months": {
     "0": "January",

--- a/app/frontend/pages/ProgressPage.vue
+++ b/app/frontend/pages/ProgressPage.vue
@@ -1,17 +1,146 @@
 <template>
-  <div>
-    <h1>{{ $t('pageTitles.progress') }}</h1>
-   <p>This is the progress page</p>
-   <p>days checked in: {{ progs.length }}</p>
-   <p>completed days: {{ completedProgs.length }}</p>
+  <div class="mx-auto max-w-sm">
+    <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.progress') }}</h1>
+
+    <h2 class="mb-16 text-2xl text-center">
+      {{ $t('progressPage.completedText', { count: completedProgs.length }) }}
+    </h2>
+
+    <p>days checked in: {{ progs.length }}</p>
+    <p>completed days: {{ completedProgs.length }}</p>
+
+
+    <div v-for="(month, monthIndex) in tables" :key="monthIndex">
+      <h3>{{ month.nameString }}</h3>
+
+      <table
+        class="text-dft-black rounded-dft-md border-separate border-spacing-2 w-full border border-dft-light-grey bg-dft-white">
+
+        <caption class="sr-only">{{ $t('progressPage.tableCaptionMonth', { month: month.nameString, count: month.completedDates.length }) }}</caption>
+
+        <thead>
+          <tr>
+            <th scope="col" v-for="i in 7">
+              <span aria-hidden="true">{{ $t(`daysOfTheWeek.${i-1}.abbreviation`) }}</span>
+              <span class="sr-only">{{ $t(`daysOfTheWeek.${i-1}.name`) }}</span>
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr v-for="(week, weekIndex) in month.dates" :key="weekIndex">
+            <td class="p-2 text-center font-subtle text-sm rounded-dft-sm" v-for="(day, dayIndex) in week"
+              :key="dayIndex"
+              :class="day.isComplete && day.isSameMonth ? 'bg-dft-primary' : day.isSameMonth ? 'bg-dft-grey-mid' : 'bg-dft-grey-light'">
+              <span class="sr-only">
+                {{ day.isComplete ? $t('progressPage.statusComplete') : $t('progressPage.statusIncomplete') }}
+              </span>
+              {{ getDate(day.date) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Prog } from '../types'
-const props = defineProps<{ progs: Prog[] }>()
+import { format, getDate, eachDayOfInterval, eachWeekOfInterval, eachMonthOfInterval, addDays, addMonths, isEqual } from "date-fns"
 
-const progs = props.progs
+import { useI18n } from 'vue-i18n'
 
-const completedProgs = progs.filter(prog => prog.completed)
+import { Prog, Startdate } from '../types'
+const { progs, startdate } = defineProps<{ progs: Prog[], startdate: Startdate }>()
+
+const useFormat = (dateToFormat) => {
+  return format(dateToFormat, 'yyyy-MM-dd')
+}
+
+const { t } = useI18n() // use as global scope
+
+const completedProgs = progs.filter(prog => prog.completed).map(el => new Date(el.completed_at))
+
+const allMonthsStartDates: any[] = eachMonthOfInterval({
+  start: new Date(startdate),
+  end: new Date()
+})
+
+const monthNameTranslation = (monthIndex) => {
+  return t(`months.${allMonthsStartDates[monthIndex].getMonth()}`)
+}
+
+const isCompletedDay = (dateToCheck) => {
+  const completedProgMatch = completedProgs.find(el => {
+    return isEqual(useFormat(el), useFormat(new Date(dateToCheck)))
+  })
+
+  return !!completedProgMatch
+}
+
+const isSameMonth = (dateToCheck, monthToCheck) => {
+  const currentMonth = new Date(monthToCheck).getMonth()
+  const dateMonth = new Date(dateToCheck).getMonth()
+
+  return currentMonth === dateMonth
+}
+
+const getEachWeekOfMonth = (monthStart: string) => {
+  return eachWeekOfInterval({
+    start: new Date(monthStart),
+    end: addMonths(monthStart, 1)
+  })
+}
+
+const getEachDayOfWeek = (weekStart: any) => {
+  const days = eachDayOfInterval({
+    start: new Date(weekStart),
+    end: addDays(weekStart, 6)
+  })
+
+  days.map(day => useFormat(day))
+
+  return days
+}
+
+const tables: any[] = []
+for (let i = 0; i < allMonthsStartDates.length; i++) {
+  // Make a new array in the tables array. Visually this will be one calendar month.
+  const monthData: Record<string, any> = {
+    nameString: t(`months.${allMonthsStartDates[i].getMonth()}`),
+    dates: [],
+    completedDates: []
+  }
+
+  const currentMonthStartDate = allMonthsStartDates[i]
+
+  // Fill the month with each of the weeks
+  const weeksOfMonth = getEachWeekOfMonth(currentMonthStartDate)
+
+  // Fill each week with day objects
+  weeksOfMonth.forEach(week => {
+    const daysOfWeek = getEachDayOfWeek(new Date(week)).map(day => {
+      const dayIsCompleted = isCompletedDay(day)
+      const dayIsInSameMonth = isSameMonth(day, currentMonthStartDate)
+
+      if(dayIsCompleted && dayIsInSameMonth) monthData.completedDates.push(day)
+
+      return { 
+        date: day, 
+        isComplete: dayIsCompleted, 
+        isSameMonth: dayIsInSameMonth
+ 
+      }
+    })
+
+    monthData.dates.push(daysOfWeek)
+  })
+
+  tables.push(monthData)
+}
+
+
+
+// TODO: Can we make an accessible tooltip here?
+// TODO: Make the week view
+// TODO: Units!
 </script>

--- a/app/frontend/pages/ProgressPage.vue
+++ b/app/frontend/pages/ProgressPage.vue
@@ -2,22 +2,30 @@
   <div class="mx-auto max-w-sm">
     <h1 class="mb-24 text-4xl text-center">{{ $t('pageTitles.progress') }}</h1>
 
-    <h2 class="mb-16 text-2xl text-center">
+    <h2 class="sr-only">{{ $t('progressPage.stats') }}</h2>
+    <p class="text-2xl text-dft-grey-mid mb-8">
       {{ $t('progressPage.completedText', { count: completedProgs.length }) }}
-    </h2>
+    </p>
 
-    <div>
+    <p class="text-5xl text-center mb-6">
+      <span aria-hidden="true">{{ percentCompleted }}%</span>
+      <span class="sr-only">{{ $t('progressPage.completedPercent', { percent: percentCompleted }) }}</span>
+    </p>
+    <div class="w-full rounded-full border-dft-primary border h-8 mb-24 overflow-hidden">
+      <div class="bg-dft-primary h-full rounded-l-full" :class="`w-[${percentCompleted}%]`" />
+    </div>
+
+    <h2 class="sr-only">{{ $t('progressPage.calendar') }}</h2>
+    <section class="mb-14">
       <div class="flex items-center -ml-4">
         <button @click="goBack" class="min-w-11 min-h-11 flex items-center justify-center"
-          :aria-label="$t('labels.calendar.backMonth')" aria-controls="monthInfo"
-          :aria-invalid="previousDatesError"
+          :aria-label="$t('labels.calendar.backMonth')" aria-controls="monthInfo" :aria-invalid="previousDatesError"
           :aria-errormessage="previousDatesError ? 'monthInfo' : undefined">
           <BaseIcon icon="arrowLeft" />
         </button>
         <h3 class="text-xl">{{ currentTable.nameString }}, {{ currentTable.year }}</h3>
         <button @click="goForward" class="min-w-11 min-h-11 flex items-center justify-center"
-          :aria-label="$t('labels.calendar.forwardMonth')" aria-controls="monthInfo"
-          :aria-invalid="futureDatesError"
+          :aria-label="$t('labels.calendar.forwardMonth')" aria-controls="monthInfo" :aria-invalid="futureDatesError"
           :aria-errormessage="futureDatesError ? 'monthInfo' : undefined">
           <BaseIcon icon="arrowRight" />
         </button>
@@ -54,17 +62,17 @@
         <tbody>
           <tr v-for="(week, weekIndex) in currentTable.dates" :key="weekIndex">
             <td class="p-2 text-center font-subtle text-sm rounded-dft-sm" v-for="(day, dayIndex) in week"
-              :key="dayIndex"
-              :class="cellClasses(day)">
+              :key="dayIndex" :class="cellClasses(day)">
               <span class="sr-only" v-if="day.isSameMonth">
-                {{ day.isComplete ? $t('progressPage.statusComplete') : day.isPartiallyComplete ? $t('progressPage.statusPartiallyComplete') : $t('progressPage.statusIncomplete') }}
+                {{ day.isComplete ? $t('progressPage.statusComplete') : day.isPartiallyComplete ?
+                  $t('progressPage.statusPartiallyComplete') : $t('progressPage.statusIncomplete') }}
               </span>
               {{ getDate(day.date) }}
             </td>
           </tr>
         </tbody>
       </table>
-    </div>
+    </section>
   </div>
 </template>
 
@@ -194,7 +202,7 @@ const cellClasses = (day) => {
 
   if (day.isComplete) return 'bg-dft-primary outline outline-black'
 
-  return 'bg-dft-grey-mid' 
+  return 'bg-dft-grey-mid'
 }
 
 
@@ -226,9 +234,9 @@ const goForward = () => {
   }
 }
 
+const percentCompleted = Math.round((100 * completedProgs.length) / 182)
 
-
-// TODO: Can we make an accessible tooltip here?
+// TODO: Can we make an accessible tooltip for each of the days?
 // TODO: Make the week view
 // TODO: Units!
 </script>

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -11,3 +11,5 @@ export type Prog = {
   completed_at: Date,
   date: Date
 }
+
+export type Startdate = string

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -9,6 +9,7 @@ export type Prog = {
   id: number,
   completed: boolean,
   completed_at: Date,
+  created_at: Date,
   date: Date
 }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_17_005822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "counters", force: :cascade do |t|
+    t.integer "click"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "daily_progs", force: :cascade do |t|
     t.bigint "goal_id", null: false
     t.date "date"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/typography": "^0.5.13",
     "@vitejs/plugin-vue": "^5.0.5",
     "autoprefixer": "^10.4.19",
+    "date-fns": "^4.1.0",
     "postcss": "^8.4.38",
     "stimulus-vite-helpers": "^3.1.0",
     "tailwindcss": "^3.4.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,14 +14,19 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['Righteous', ...defaultTheme.fontFamily.sans],
+        subtle: ['Arial', ...defaultTheme.fontFamily.sans]
       },
       borderRadius: {
+        'dft-md': '10px',
+        'dft-sm': '5px',
         'dft-input': '20px'
       },
       colors: {
         'dft-white': '#FFFFFF',
         'dft-black': '#000000',
         'dft-grey': '#3a3a3a', // Dark grey
+        'dft-grey-mid': '#D9D9D9', // Mid grey
+        'dft-grey-light': '#FAFAFA', // Light grey
         'dft-primary': '#F196F9', // Candy pink
         'dft-secondary': '#90F8FF', // Light blue
         'dft-secondary-dimmed': '#68D5DC',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2983,6 +2983,11 @@ data-urls@^5.0.0:
     whatwg-mimetype "^4.0.0"
     whatwg-url "^14.0.0"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
## Work done

This PR adds a monthly calendar and progress bar to the Progress page.

## Testing instructions

Visual testing
0. You may need to populate the db first!
1. Navigate to the Progress page: http://localhost:3002/progress
- Expect the layout to look roughly like [the Figma](https://www.figma.com/design/wBpAWs2jxyNCuI6u6mOYjw/DFT-APP?node-id=120-743&t=e1gdUkULFZgsWipu-4) (with the exception of the weekly progress calendar)

SR testing
1. Arrow through the statistics area
- Expect to hear how many days of the total you've done
- Expect to hear what percentage is complete
2. Arrow through to the calendar area.
- Expect to hear the calendar heading
3. Arrow to the < button
- Expect to hear go to previous dates
4. Arrow to the > button
- Expect to hear go to next dates
5. Click the back or the forward buttons
- Expect to hear the new current month
6. Click the back or the forward buttons when you know there won't be a month available
- Expect to hear that there are no future/previous months available
- Expect to see the error text letting you know that there are no previous/future months available.
7. Arrow through a month with some completed and partial dates.
- On days which aren't in the current month, expect to hear only the day of the month (e.g. "4")
- On days which are in the current month but are incomplete, expect to hear incomplete and the day of the month
- On days which are in the current month and are partially complete, expect to hear partially complete and the day of the month
- On days which are in the current month and are complete, expect to hear complete and the day of the month