### PR TITLE
chore: Hide skiplink until focused render-preview

### DIFF
--- a/app/frontend/layouts/BaseLayout.vue
+++ b/app/frontend/layouts/BaseLayout.vue
@@ -1,13 +1,13 @@
 <template>
   <main class="flex flex-col min-h-screen p-4 appBg">
-    <header class="border-4">
-      <a href="#footerNav">Skip to nav (TODO: Hide until focused with keyboard)</a>
+    <header>
+      <a href="#footerNav" class="sr-only focus:not-sr-only">{{ $t('nav.skipLink') }}</a>
     </header>
     <article class="grow">
 
       <slot />
     </article>
-    <footer id="footerNav" class="rounded-t-xl bg-dft-secondary">
+    <footer id="footerNav" class="rounded-t-xl bg-dft-secondary" tabindex="-1">
       <ul class="flex justify-center">
         <li class="basis-36 max-w-36">
           <NavLink linkDest="/settings" icon="cog">

--- a/app/frontend/locales/en.json
+++ b/app/frontend/locales/en.json
@@ -28,6 +28,7 @@
     "progress": "Progress"
   },
   "nav": {
+    "skipLink": "Skip to navigation",
     "settings": "Settings",
     "today": "Today",
     "progress": "Progress"


### PR DESCRIPTION
## Context

A user on SR and/or keyboard, wanting to navigate directly to the navigation.

## Work done

Hid the skiplink till focused, and when clicked, focus on the footer nav.

## Manual testing instructions
1. serve app
2. Using keyboard only, tab to the site
- Expect the "Skip to navigation" to become visible
3. Click the link (enter/spacebar on keyboard is fine)
- Expect focus to shift to the footer nav